### PR TITLE
Ellipse line width integration in plot.PCA and plotellipses 

### DIFF
--- a/R/plot.PCA.R
+++ b/R/plot.PCA.R
@@ -1,5 +1,5 @@
 plot.PCA <- function (x, axes = c(1, 2), choix = c("ind","var","varcor"),
-                      ellipse = NULL, xlim = NULL, ylim = NULL, habillage = "none", 
+                      ellipse = NULL, ellipselwd = 1, xlim = NULL, ylim = NULL, habillage = "none", 
                       col.hab = NULL, col.ind = "black", col.ind.sup = "blue", 
                       col.quali = "magenta", col.quanti.sup = "blue", 
                       col.var = "black", label=c("all","none","ind", "ind.sup", "quali", "var", "quanti.sup"), 
@@ -477,10 +477,10 @@ plot.PCA <- function (x, axes = c(1, 2), choix = c("ind","var","varcor"),
         else{
           if(graph.type=="ggplot"){
             if (habillage[1] != "none"){
-              gg_graph <- gg_graph + geom_path(aes_string(x=data.elli[,1],y=data.elli[,2]), color = palette[color.mod[e]])
+              gg_graph <- gg_graph + geom_path(aes_string(x=data.elli[,1],y=data.elli[,2]), size = ellipselwd, color = palette[color.mod[e]])
             }
             else {
-              gg_graph <- gg_graph + geom_path(aes_string(x=data.elli[,1],y=data.elli[,2]), color = palette[col.quali])
+              gg_graph <- gg_graph + geom_path(aes_string(x=data.elli[,1],y=data.elli[,2]), size = ellipselwd, color = palette[col.quali])
             }
           }
         }

--- a/R/plotellipses.r
+++ b/R/plotellipses.r
@@ -1,5 +1,5 @@
 plotellipses <- function (model, keepvar = "all", axes = c(1, 2), means = TRUE, 
-                              level = 0.95, magnify = 2, cex = 1, pch = 20, pch.means = 15, 
+                              level = 0.95, magnify = 2, ellipselwd = 1, cex = 1, pch = 20, pch.means = 15, 
                               type = c("g", "p"), keepnames = TRUE, namescat = NULL, xlim = NULL, 
                               ylim = NULL, lwd = 1, label = "all",
 							  autoLab = c("auto","yes", "no"), graph.type=c("ggplot","classic"), ...) 
@@ -286,7 +286,7 @@ plotellipses <- function (model, keepvar = "all", axes = c(1, 2), means = TRUE,
 	  res.pca$ind$contrib[,axes] <- model$ind$contrib[,axes]
       coord.ell <- coord.ellipse(aux, bary = means, level.conf = level, axes = axes)
         L <- list(x=res.pca, habillage = 1, ellipse = coord.ell, 
-                  cex = cex, label = label, axes = axes, xlim = xlim, 
+                  cex = cex, label = label, axes = axes, xlim = xlim, ellipselwd = ellipselwd,
                   ylim = ylim, title = paste(if (means == TRUE){"Confidence ellipses around the categories of"} else {"Concentration ellipses for the categories of"}, 
                                              colnames(model$call$X)[var]), autoLab = autoLab, graph.type=graph.type)
       # if (means == TRUE) {


### PR DESCRIPTION
Easy implementation of Ellipse lwd for plot.PCA and plotellipses.

ellipselwd : The line width of ellipses, a positive number, defaulting to 1

If plotellipses 'lwd' argument was the way to go, i wasn't able to make it work at all. 

 